### PR TITLE
Jun2024: Removal of Math Alive Slides on 7 Jun

### DIFF
--- a/_parents-portal/Downloads & Links.md
+++ b/_parents-portal/Downloads & Links.md
@@ -6,11 +6,6 @@ variant: markdown
 ---
 ![](/images/banner.gif)
 
-##### **2024 Maths Alive! Parent Workshop&nbsp;\*NEW!**
-* [P1 Slides](/files/P1_Math_Alive_Parents_Workshop_2024.pdf)<br>
-* [P2 Slides](/files/P2_Math_Alive_Parents_Workshop_2024.pdf)<br>
-* [P3 &amp; P4 Slides](/files/P3_P4_Math_Alive_Parents_Workshop_2024.pdf)<br>
-* [P5 &amp; P6 Slides](/files/P5_P6_Math_Alive_Parents_Workshop_2024.pdf)<br>
 
 ##### **2024 Primary 1 Matters&nbsp;\*NEW!**
 


### PR DESCRIPTION
Dear Evelyn,
For your approval on the above changes to remove the Math Alive Slides.
Thanks 